### PR TITLE
Baccarat: python3 compatibility.

### DIFF
--- a/data/states/baccarat/__init__.py
+++ b/data/states/baccarat/__init__.py
@@ -1,1 +1,1 @@
-from baccarat import Baccarat
+from .baccarat import Baccarat

--- a/data/states/baccarat/baccarat.py
+++ b/data/states/baccarat/baccarat.py
@@ -13,7 +13,7 @@ import pygame as pg
 from ... import tools, prepare
 from . import layout
 from .ui import *
-import fysom
+from . import fysom
 import json
 import os
 import math

--- a/data/states/baccarat/ui.py
+++ b/data/states/baccarat/ui.py
@@ -315,8 +315,9 @@ class Deck(Stacker):
     """
     def __init__(self, rect, card_size=prepare.CARD_SIZE, shuffle=True,
                  decks=0, stacking=None):
-        if rect[2:] == (0, 0):
-            rect = rect[:2], card_size
+        rect = pygame.Rect(rect)
+        if rect.size == (0, 0):
+            rect = pygame.Rect(rect.topleft, card_size)
         super(Deck, self).__init__(rect, stacking)
         self.card_size = card_size
         self.shuffle = shuffle


### PR DESCRIPTION
Fixed imports.
Python3 pygame.Rect doesn't understand slices.