### PR TITLE
Baccarat: py3 bug fix with count card.

### DIFF
--- a/data/states/baccarat/baccarat.py
+++ b/data/states/baccarat/baccarat.py
@@ -28,9 +28,10 @@ font_size = 64
 
 
 def count_card(value):
-    if value > 9:
+    try:
+        return 0 if value > 9 else value
+    except TypeError:
         return 0
-    return value
 
 
 def count_hand(deck):


### PR DESCRIPTION
Comparing a class with an int doesn't work in py3 without overloading relevant operators.

Previously receiving this traceback in py3.4:
```
Traceback (most recent call last):
  File "pyroller.py", line 8, in <module>
    main()
  File "C:\Python27\Lib\Python modules\Mine\pyroller\data\main.py", line 45, in
main
    run_it.main()
  File "C:\Python27\Lib\Python modules\Mine\pyroller\data\tools.py", line 139, i
n main
    self.update(time_delta)
  File "C:\Python27\Lib\Python modules\Mine\pyroller\data\tools.py", line 57, in
 update
    self.state.update(self.render_surf,self.keys,self.now,dt,self.scale)
  File "C:\Python27\Lib\Python modules\Mine\pyroller\data\states\baccarat\baccar
at.py", line 459, in update
    self.animations.update(dt)
  File "c:\python34\lib\site-packages\pygame\sprite.py", line 462, in update
    s.update(*args)
  File "C:\Python27\Lib\Python modules\Mine\pyroller\data\components\animation.p
y", line 34, in update
    self.callback(*self._args, **self._kwargs)
  File "C:\Python27\Lib\Python modules\Mine\pyroller\data\states\baccarat\baccar
at.py", line 243, in count_naturals
    if natural(self.player_hand):
  File "C:\Python27\Lib\Python modules\Mine\pyroller\data\states\baccarat\baccar
at.py", line 60, in natural
    return count_card(deck) >= 8 and len(deck) == 2
  File "C:\Python27\Lib\Python modules\Mine\pyroller\data\states\baccarat\baccar
at.py", line 32, in count_card
    if value > 9:
TypeError: unorderable types: Deck() > int()
```