### PR TITLE
Straight args change; Control scaling change.

### DIFF
--- a/data/states/title_screen.py
+++ b/data/states/title_screen.py
@@ -65,9 +65,10 @@ class TitleScreen(tools._State):
         Check options to go straight to a particular game
         rather than showing the lobby - good for debugging.
         """
-        if prepare.ARGS['straight']:
+        straight = prepare.ARGS['straight']
+        if straight and straight != "TITLESCREEN":
             self.persist["casino_player"] = CasinoPlayer(self.stats)
-            self.next = prepare.ARGS['straight']
+            self.next = straight
             self.done = True
         else:
             self.next = "LOBBYSCREEN"

--- a/data/tools.py
+++ b/data/tools.py
@@ -58,13 +58,17 @@ class Control(object):
         if self.music_handler and self.state.use_music_handler:
             self.music_handler.update(self.scale)
             self.music_handler.draw(self.render_surf)
+
+    def render(self):
+        """
+        Scale the render surface if not the same size as the display surface.
+        The render surface is then drawn to the screen.
+        """
         if self.render_size != self.screen_rect.size:
-            scale_args = (self.render_surf, self.screen_rect.size)
-            scaled_surf = pg.transform.smoothscale(*scale_args)
-            self.screen.blit(scaled_surf, (0, 0))
+            scale_args = (self.render_surf, self.screen_rect.size, self.screen)
+            pg.transform.smoothscale(*scale_args)
         else:
             self.screen.blit(self.render_surf, (0, 0))
-
 
     def flip_state(self):
         """
@@ -137,6 +141,7 @@ class Control(object):
             time_delta = self.clock.tick(self.fps)
             self.event_loop()
             self.update(time_delta)
+            self.render()
             pg.display.update()
             if self.show_fps:
                 fps = self.clock.get_fps()

--- a/test/testcontrol.py
+++ b/test/testcontrol.py
@@ -200,18 +200,17 @@ class TestControl(unittest.TestCase):
         self.c.update(10)
         # Nothing to test - should just work
 
-    def testUpdateShouldScaleScreen(self):
-        """update method should scale the screen"""
+    def testRenderShouldScaleScreen(self):
+        """Control.render method should scale the screen"""
         #
-        # We will render something in the state at a higher resolution and then
-        # use the control to scale back down
+        # We will creatae an image at a higher resolution and then
+        # use the control render method to scale back down.
         w, h = 100, 100
         self.c = SimpleControl('control', (w, h), [])
-        self.c.setup_states(self.states, 'one')
-        #
+
         self.c.render_size = (w, h)
         real_surface = pg.Surface(self.c.render_size)
-        self.c.state._surface_to_render = real_surface
+        self.c.render_surf = real_surface
         real_surface.fill((255, 0, 0))
         pg.draw.rect(real_surface, (0, 255, 0), (10, 10, 80, 80))
         #
@@ -221,8 +220,8 @@ class TestControl(unittest.TestCase):
         for point in ((11, 11), (11, 88), (88, 11), (88, 88)):
             self._checkPoint((0, 255, 0), real_surface, point, 'green', 1, False)
         #
-        # Now call update, which should create a scaled down version of this
-        self.c.update(10)
+        # Now call render, which should create a scaled down version of this
+        self.c.render()
         #pg.image.save(self.c.render_surf, 'test1.png')
         #pg.image.save(self.c.screen, 'test2.png')
         #


### PR DESCRIPTION
The -S arg had an issue where it didn't work if you tried to go straight to the title screen.

Final scaling and blitting in Control moved into a render method.  
The scaling now blits directly to self.screen rather than creating an intermediary surface.

One test changed:
testUpdateShouldScaleScreen ---> testRenderShouldScaleScreen

All tests pass.