### PR TITLE
Baccarat: Py3 division compatibility fix.

### DIFF
--- a/data/components/dialog.py
+++ b/data/components/dialog.py
@@ -16,8 +16,8 @@ class GraphicBox(object):
     """
     def __init__(self, image, hollow=False):
         iw, ih = image.get_size()
-        self.tw = iw / 3
-        self.th = ih / 3
+        self.tw = iw // 3
+        self.th = ih // 3
         self.hollow = hollow
 
         tiles = [image.subsurface((x, y, self.tw, self.th))


### PR DESCRIPTION
Range doesn't accept floats.  True division was crashing in py3.