### PR TITLE
Minor Video Poker 'Cash Out' and 'Lobby' Button Tweaks

### DIFF
--- a/data/states/video_poker/video_poker.py
+++ b/data/states/video_poker/video_poker.py
@@ -16,6 +16,7 @@ class VideoPoker(tools._State):
         self.casino_player = None
 
     def back_to_lobby(self, *args):
+        self.machine.cash_out()
         self.done = True
         self.next = "LOBBYSCREEN"
 

--- a/data/states/video_poker/video_poker_machine.py
+++ b/data/states/video_poker/video_poker_machine.py
@@ -330,13 +330,16 @@ class Machine:
         self.dealer.waiting = True
 
     def cash_out(self, *args):
+        total_credits = self.credits
+        self.credits = 0
+
         if self.state == "GAME OVER":
-            total_credits = self.credits + self.current_bet
-            self.credits = 0
+            total_credits += self.current_bet
             self.current_bet = 0
-            self.player.stats['cash'] += total_credits
-            for _ in range(total_credits):
-                self.credits_sound.play()
+
+        self.player.stats['cash'] += total_credits
+        for _ in range(total_credits):
+            self.credits_sound.play()
 
     def toggle_buttons(self, buttons, active=True):
         for button in buttons:


### PR DESCRIPTION
I noticed that the 'Lobby' button didn't automatically return money to the player that had been inserted into the machine. This pull request addresses that by returning non-wagered money back to the player when 'Lobby' is clicked. It also changes the 'Cash Out' behavior by allowing a cash out of non-wagered money during a game in progress.